### PR TITLE
publish to fanout exchange instead of direct send to queue

### DIFF
--- a/servers/processor/payments/main.ts
+++ b/servers/processor/payments/main.ts
@@ -53,7 +53,7 @@ function handlePaymentMessage(payment: Payment) {
 				log.info("invoices:paid", invoice.uid);
 
         await channel.ack(message);
-        await channel.sendToQueue('invoices:paid', new Buffer(invoice.uid));
+        await channel.publish('anypay:invoices', 'invoice:paid', new Buffer(invoice.uid));
 
         Slack.notify(
           `invoice:${invoice.status} https://pos.anypay.global/invoices/${invoice.uid}`


### PR DESCRIPTION
The purpose of this change is to enable multiple processes to listen for paid invoices.

Currently when an invoice is paid a message is sent out to a single queue. We want multiple queues to be able to receive the message that an invoice is paid.

Such behavior is affected by publishing to an `exchange` rather than directly to a `queue`. Any number of queues can have a binding to an exchange using a routing key.

In this case the exchange is named `anypay:invoices` and the routing key is named `invoice:paid`.

In the future all messages should be published to an exchange instead of of directly to a queue, so that multiple processes can receive the message and react to it.

