### PR TITLE
[lib, servers] update route config for client modelgen

### DIFF
--- a/lib/models/access_token.js
+++ b/lib/models/access_token.js
@@ -2,6 +2,7 @@ const Sequelize = require('sequelize');
 const sequelize = require('../database');
 const Account = require('./account');
 const uuid = require('uuid');
+const Joi = require('joi');
 
 const AccessToken = sequelize.define('access_token', {
   uid: Sequelize.STRING,
@@ -23,3 +24,7 @@ const AccessToken = sequelize.define('access_token', {
 
 module.exports = AccessToken;
 
+module.exports.Response = Joi.object({
+  uid: Joi.string().required(),
+  account_id: Joi.number().integer().required(),
+}).label("AccessToken");

--- a/lib/models/invoice.js
+++ b/lib/models/invoice.js
@@ -70,7 +70,7 @@ module.exports.Response = Joi.object({
   uid: Joi.string().required(),
   currency: Joi.string().required(),
   amount: Joi.number().required(),
-  dollar_amount: Joi.number().required(),
+  dollar_amount: Joi.string().required(),
   address: Joi.string().required(),
   account_id: Joi.number().integer().required(),  
   access_token: Joi.string(),

--- a/lib/models/pair_token.js
+++ b/lib/models/pair_token.js
@@ -3,6 +3,7 @@ const sequelize = require('../database');
 const Account = require('./account');
 const AccessToken = require('./access_token');
 const crypto = require('crypto');
+const Joi = require('joi');
 
 const PairToken = sequelize.define('pair_token', {
   uid: Sequelize.STRING,
@@ -34,4 +35,11 @@ const PairToken = sequelize.define('pair_token', {
 });
 
 module.exports = PairToken;
+
+module.exports.Response = Joi.object({
+  uid: Joi.string().required(),
+  device_name: Joi.string().required(),
+  access_token_id: Joi.string().required(),
+  account_id: Joi.string().required(),
+}).label('PairToken');
 

--- a/servers/rest_api/server.ts
+++ b/servers/rest_api/server.ts
@@ -141,6 +141,7 @@ const validateToken = async function(request, username, password, h) {
   }
 };
 
+// Unused
 const kBasicAuthorizationAllowOtherHeaders = Joi.object({
   authorization: Joi.string().regex(/^(Basic) \w+/g).required()
 }).unknown()
@@ -161,6 +162,10 @@ function responsesWithSuccess({ model }) {
         },
         400: {
           description: 'Bad Request',
+          schema: kBadRequestSchema,
+        },
+        401: {
+          description: 'Unauthorized',
           schema: kBadRequestSchema,
         },
       },
@@ -192,7 +197,15 @@ async function Server() {
       info: {
         title: 'Anypay API Documentation',
         version: '1.0.1',
-      }
+      },
+      securityDefinitions: {
+        simple: {
+          type: 'basic',
+        },
+      },
+      security: [{
+        simple: [],
+      }],
     }
   })
 
@@ -209,7 +222,7 @@ async function Server() {
           invoice_id: Joi.string().required()
         },
       },
-      plugins: responsesWithSuccess({ model: Invoice.Resposne })
+      plugins: responsesWithSuccess({ model: Invoice.Response })
     },
   });
   server.route({
@@ -218,9 +231,6 @@ async function Server() {
     config: {
       auth: "token",
       tags: ['api'],
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
-      },
       handler: InvoicesController.index,
       plugins: responsesWithSuccess({ model: DashBoardController.IndexResponse })
     }
@@ -231,9 +241,6 @@ async function Server() {
     config: {
       auth: "token",
       tags: ['api'],
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
-      },
       handler: DashBoardController.index,
       plugins: responsesWithSuccess({ model: DashBoardController.IndexResponse })
     }
@@ -253,9 +260,6 @@ async function Server() {
     config: {
       auth: "token",
       tags: ['api'],
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
-      },
       handler: PairTokensController.show
     }
   });
@@ -266,7 +270,6 @@ async function Server() {
       auth: "token",
       tags: ['api'],
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         payload: Invoice.Request,
       },
       handler: BitcoinCashInvoicesController.create
@@ -280,7 +283,6 @@ async function Server() {
       auth: "token",
       tags: ['api'],
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         payload: Invoice.Request,
       },
       handler: ZcashInvoicesController.create,
@@ -308,7 +310,6 @@ async function Server() {
       auth: "token",
       tags: ['api'],
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         payload: Invoice.Request,
       },
       handler: DashInvoicesController.create,
@@ -322,7 +323,6 @@ async function Server() {
       auth: "token",
       tags: ['api'],
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         payload: Invoice.Request,
       },
       handler: BitcoinInvoicesController.create,
@@ -336,7 +336,6 @@ async function Server() {
       auth: "token",
       tags: ['api'],
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         payload: Invoice.Request,
       },
       handler: LitecoinInvoicesController.create,
@@ -350,7 +349,6 @@ async function Server() {
       auth: "token",
       tags: ['api'],
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         payload: Invoice.Request,
       },
       handler: DogecoinInvoicesController.create,
@@ -384,10 +382,8 @@ async function Server() {
     config: {
       auth: "password",
       tags: ['api'],
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders
-      },
-      handler: AccessTokensController.create
+      handler: AccessTokensController.create,
+      plugins: responsesWithSuccess({ model: AccessToken.Response })
     }
   });
   server.route({
@@ -396,9 +392,6 @@ async function Server() {
     config: {
       auth: "token",
       tags: ['api'],
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
-      },
       handler: AddressesController.list,
       plugins: responsesWithSuccess({ model: AddressesController.PayoutAddresses }),
     }
@@ -410,7 +403,6 @@ async function Server() {
       auth: "token",
       tags: ['api'],
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         params: {
           currency: Joi.string().required()
         },
@@ -426,9 +418,6 @@ async function Server() {
     config: {
       auth: "token",
       tags: ['api'],
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders
-      },
       handler: AccountsController.show,
       plugins: responsesWithSuccess({ model: Account.Response }),
     }
@@ -439,9 +428,6 @@ async function Server() {
     config: {
       auth: "token",
       tags: ['api'],
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders
-      },
       handler: ExtendedPublicKeysController.index
     }
   });
@@ -452,7 +438,6 @@ async function Server() {
       auth: "token",
       tags: ['api'],
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         payload: ExtendedPublicKeysController.ExtendedPublicKey
       },
       handler: ExtendedPublicKeysController.create,
@@ -465,9 +450,6 @@ async function Server() {
     config: {
       tags: ['api'],
       auth: "token",
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders
-      },
       handler: CoinsController.list,
       plugins: responsesWithSuccess({ model: CoinsController.CoinsIndexResponse }),
     }
@@ -480,7 +462,6 @@ async function Server() {
       tags: ['api'],
       handler: InvoicesController.create,
       validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
         payload: Invoice.Request,
       },
       plugins: responsesWithSuccess({ model: Invoice.Response }),
@@ -491,9 +472,6 @@ async function Server() {
     path: "/pair_tokens/{uid}",
     config: {
       tags: ['api'],
-      validate: {
-        headers: kBasicAuthorizationAllowOtherHeaders,
-      },
       handler: PairTokensController.claim
     }
   });


### PR DESCRIPTION
Does the validate: authorization header kill the request if it's not bearing the header or validate the token for the handler?  I may need to check in the generated models and contribute back to hapi-swagger or swagger-models for this case, and it seems general enough.

The problem is that including a validate: header: authorization block in the route() config, with or without the security definitions in register() generates api methods that require the header at the call site instead of using the Session's token.

```swift
InvoicesAPI.getInvoices(with authorizationHeader: String, completion: (Invoices) -> Void)
```

as opposed to

```swift
session.headers["authorization"] = token
// ...
InvoicesAPI.getInvoices(completion: (Invoices) -> Void)
```

But if this code will fit your use case in server, even better.