### PR TITLE
Bug fix ZEN plugin checkAddressForPayments

### DIFF
--- a/plugins/zen/lib/checkAddressForPayments.ts
+++ b/plugins/zen/lib/checkAddressForPayments.ts
@@ -25,16 +25,19 @@ export async function anypay_checkAddressForPayments(address:string, currency:st
     for(let i = 0; i<resp.transactions.length;i++){
 
       let tx = await rpc.getTransaction(resp.transactions[i])
- 
+
+
       for( let j=0; j<tx.vout.length;j++){
-  
+
+	if(tx.vout[j].scriptPubKey.addresses[0] != address ){continue}	
+
         let p: Payment  = {
   
           hash: resp.transactions[i],
   
           amount: tx.vout[j].value,
  
-          address: address,
+          address: tx.vout[j].scriptPubKey.addresses[0],
   
           currency: 'ZEN'
  

--- a/plugins/zen/test/checkAddressForPayments_test.ts
+++ b/plugins/zen/test/checkAddressForPayments_test.ts
@@ -1,18 +1,34 @@
 import {checkAddressForPayments} from '../index';
 
 require('dotenv').config();
+  
+import {Payment,Invoice} from '../../../types/interfaces';
+
+const assert = require("assert");
 
 describe("Checking address for payments", () => {
 
   it ("should return an array of payments", async () => {
 
-    let address = 'znTxg7ux8LSRLBCowM4bMLjVqX5Gaw4irwZ';
+    let address = 'znTdCH8u6G9bviMVwuQGtcuYdMhoHVJXSaN';
 
     let payments = await checkAddressForPayments(address, 'ZEN');
 
     console.log(payments);
 
+    for( let i = 0; i<payments.length;i++){
+      assert(payments[i].address == address)
+    }
+
+    assert(payments[0].amount == 2.22277017)
+
+    assert(payments[1].amount == .07490649)
+
+
   });
+  
+ 
+
 
 });
 


### PR DESCRIPTION
ZEN cash checkAddressForPayments was publishing payment messages with incorrect addresses.
  - The fix corrects the error
  - And only publishes payments with transaction outputs that have an address equal to the parameter given to checkAddressForPayments(address, currency)