### PR TITLE
Remove db query from invoices (#287)

### DIFF
--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -136,16 +136,61 @@ export async function firstInvoicePaidEmail(invoice){
 
 }
 
+async function checkInvoiceCount(invoice){
+
+  const query = `SELECT COUNT(*) FROM invoices WHERE account_id=${invoice.account_id};`
+
+  try{
+
+    var result = await database.query(query);
+
+    if(result[1].rows[0].count==1){
+
+      firstInvoiceCreatedEmail(invoice.id)
+      emitter.emit('invoice.created.first')
+
+    }
+  }catch(error){
+    log.error(error)
+  }
+
+
+}
+
+async function checkInvoicePaidCount(invoice){
+
+  const query = `SELECT COUNT(*) FROM invoices WHERE account_id=${invoice.account_id} AND status='paid';`
+  
+  try{
+  
+    var result = await database.query(query);
+
+    if(result[1].rows[0].count==1){
+      emitter.emit('invoice.paid.first', invoice)
+      firstInvoicePaidEmail(invoice)
+    }
+    else{
+      invoicePaidEmail(invoice)
+    }
+
+  }catch(err){
+    log.error(err)
+  }
+
+}
+
 emitter.on('account.created', (account) => {
    
   newAccountCreatedEmail(account)
     
 })   
 
-emitter.on('invoice.created.first', (invoice)=>{
 
-  firstInvoiceCreatedEmail(invoice.id)
 
+emitter.on('invoice.created', (invoice)=>{
+ 
+  checkInvoiceCount(invoice)
+ 
 })
 
 emitter.on('address.set', (changeset)=>{
@@ -160,9 +205,8 @@ emitter.on('invoice.paid.first', (invoice)=>{
 
 })
 
-
 emitter.on('invoice.paid', (invoice)=>{
 
-  invoicePaidEmail(invoice) 
+  checkInvoicePaidCount(invoice)
 
 })

--- a/lib/invoice.ts
+++ b/lib/invoice.ts
@@ -151,21 +151,7 @@ export async function generateInvoice(
     dollar_amount: invoiceChangeset.denominationAmount.value // DEPRECATED
   });
 
-  const query = `SELECT COUNT(*) FROM invoices WHERE account_id=${account.id};`
-
-  try{
-
-    var result = await database.query(query);
-
-    if(result[1].rows[0].count==1){
-      emitter.emit('invoice.created.first', invoice)
-    }
-    else{
-      emitter.emit('invoice.created', invoice)
-    }
-  }catch(error){
-    log.error(error)
-  }
+  emitter.emit('invoice.created', invoice)
   
   return invoice;
 }

--- a/lib/payment_processor.ts
+++ b/lib/payment_processor.ts
@@ -72,21 +72,6 @@ export async function handlePaid(invoice: Invoice, payment: Payment) {
 
     emitter.emit('invoice.paid', invoice)
     emitter.emit('invoice.payment', invoice.uid)
-
-    const query = `SELECT COUNT(*) FROM invoices WHERE account_id=${invoice.account_id} AND status='paid';`
-  
-    try{
-  
-      var result = await database.query(query);
-
-      if(result[1].rows[0].count==1){
-        emitter.emit('invoice.paid.first', invoice)
-      } 
-
-    }catch(err){
-     log.error(err)
-    }
-
     return invoice;
   } else {
     throw new Error("error updating invoice");

--- a/test/lib/email.ts
+++ b/test/lib/email.ts
@@ -78,11 +78,11 @@ describe("Automated Emails", ()=>{
 
     })
 
-    it("should emit an event when the first invoice is created for the first time", (done)=>{
+    it("should emit an event when the first invoice is created", (done)=>{
 
       let sem = false 
 
-      emitter.on('invoice.created.first', (p)=>{
+      emitter.on('invoice.created', (p)=>{
 	if(!sem){
 	  done()
 	}

--- a/test/lib/email_invoice_paid.ts
+++ b/test/lib/email_invoice_paid.ts
@@ -25,7 +25,7 @@ describe("Emails when invoice is paid", ()=>{
 
     let sem = false 
 
-    emitter.on('invoice.paid.first', (p)=>{
+    emitter.on('invoice.paid', (p)=>{
       if(!sem){
         done()
       }


### PR DESCRIPTION
* Running a db query to count number of invoices is too expensive to do before returning an invoice.  The logic is moved to the event handler

* emit event on first invoice created

* moving await call to an async function

* remove db query from payment processor

* emmiting invoice.paid intially