### PR TITLE
replacing invoice currency when invoice is replaced

### DIFF
--- a/lib/invoice.ts
+++ b/lib/invoice.ts
@@ -264,6 +264,8 @@ export async function replaceInvoice(uid: string, currency: string) {
 
   invoice.invoice_currency = option.currency;
 
+  invoice.invoice_amount = option.amount;
+
   invoice.currency = option.currency;
 
   invoice.amount = option.amount;


### PR DESCRIPTION
@stevenzeiler replaceInvoice  does not change invoice_currency.  I thought this was a deprecated field but I see that the sudo app uses the field.  

Wanted to bring this to your attention in case you come across any weird invoices where the currency and the address don't match up