### PR TITLE
Only list valid cashback failures

### DIFF
--- a/lib/cashback/index.ts
+++ b/lib/cashback/index.ts
@@ -97,7 +97,10 @@ export async function listFailures(): Promise<any[]> {
     `select cashback_customer_payments.*, invoices.account_id, invoices.uid from
     cashback_customer_payments inner join invoices on invoices.id =
     cashback_customer_payments.invoice_id where  invoices.status = 'paid'
-    and transaction_hash is null order
+    and transaction_hash is null
+    and cashback_customer_payments.amount > 0
+    and cashback_customer_payments.cashback_merchant_id is not null
+    and cashback_customer_payments.currency in ('BCH', 'DASH') order
     by "createdAt" desc;`
   );
 


### PR DESCRIPTION
Our retry queue was overflowing with (literally) millions of messages because this auto retry every minute was pulling in way too many invalid transactions.