### PR TITLE
Btc confirming webhooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - run:
           name: Deploy to Web Servers
-          command: ssh ubuntu@api_next.anypayx.com "sudo chef-client -o recipe[anypay::api_next]"
+          command: ssh ubuntu@api.next.anypayx.com "sudo chef-client -o recipe[anypay::api_next]"
 
   deploy_beta:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,6 @@ jobs:
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             chmod +x codecov
             ./codecov
-      - run:
-          name: Tag and Release New Version
-          command: npx semantic-release
 
   build_docker:
     docker:

--- a/actors/paid_webhooks/actor.ts
+++ b/actors/paid_webhooks/actor.ts
@@ -4,7 +4,7 @@ import { log } from '../../lib/log'
 
 import { Actor } from 'rabbi'
 
-import { getPaidWebhookForInvoice, sendWebhookForInvoice } from '../../lib/webhooks';
+import { getPaidWebhookForInvoice, createWebhookForInvoice } from '../../lib/webhooks';
 
 import { ensureInvoice, Invoice } from '../../lib/invoices'
 
@@ -41,21 +41,15 @@ export async function start() {
 
       log.info('webhook', webhook)
 
-      if (webhook) {
+      if (!webhook) {
 
-        let attempt = await webhook.attemptWebhook()
-
-        log.info('webhook.attempt', attempt.record.toJSON());
-
-      } else {
-
-        log.info('webhook.sendforinvoice')
-
-        let result = await sendWebhookForInvoice(invoice.uid, 'actor_onpaid')
-
-        log.info('webhook.sendforinvoice.result', result)
+        await createWebhookForInvoice(invoice)
 
       }
+
+      let attempt = await webhook.attemptWebhook()
+
+      log.info('webhook.attempt', attempt.record.toJSON());
 
     } catch(error) {
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -31,6 +31,9 @@ config.defaults({
   // Enable Websockets Server and API for Wallet Bot
   'wallet_bot_app_enabled': true,
 
+  // Optionally require a confirmation for BTC payments -- eventually this will default to true
+  require_btc_confirmations: false,
+
   prometheus_auth_required: true,
   
   prometheus_password: '',

--- a/lib/invoice.ts
+++ b/lib/invoice.ts
@@ -114,15 +114,15 @@ export async function refreshInvoice(uid: string): Promise<Invoice> {
 
   for (let option of paymentOptions) {
 
-    const template = paymentRequest.get('template').find(template => template.currency === option.currency)
+    const template = paymentRequest.get('template').find(template => template.currency === option.get('currency'))
 
     const outputs = await Promise.all(template.to.map(async (to) => {
 
       const { currency, amount: value } = to
 
-      const conversion = await convert({ currency, value }, option.currency)
+      const conversion = await convert({ currency, value }, option.get('currency'))
 
-      const amount = pay.toSatoshis(conversion.value, option.currency)
+      const amount = pay.toSatoshis(conversion.value, option.get('currency'))
 
       return {
 
@@ -137,7 +137,7 @@ export async function refreshInvoice(uid: string): Promise<Invoice> {
     const record = await models.PaymentOption.findOne({
       where: {
         invoice_uid: invoice.uid,
-        currency: option.currency
+        currency: option.get('currency')
       }
     })
 
@@ -241,7 +241,7 @@ export async function createPaymentOptions(account, invoice): Promise<PaymentOpt
       fee: fee.amount
     })
 
-    return new PaymentOption(invoice, optionRecord)
+    return new PaymentOption(optionRecord)
 
   }));
 

--- a/lib/invoices.ts
+++ b/lib/invoices.ts
@@ -94,9 +94,7 @@ export class Invoice extends Orm {
   }
 
   get denomination(): string {
-
     return this.get('denomination_currency')
-
   }
 
   get payment(): any {
@@ -180,7 +178,7 @@ export class Invoice extends Orm {
       where: { invoice_uid: this.get('uid') }
     })
 
-    return records.map(record => new PaymentOption(this, record))
+    return records.map(record => new PaymentOption(record))
 
   }
 
@@ -271,18 +269,21 @@ export async function createInvoice(params: CreateInvoice): Promise<Invoice> {
     account_id: account.id,
 
     template: paymentOptions.map(option => {
+
       return {
-        currency: currency || account.denomination,
+        currency: option.get('currency'),
         to: [{
-          currency: option.currency,
-          amount: amount,
-          address: option.address
+          currency: record.denomination_currency,
+          amount: record.denomination_amount,
+          address: option.get('address')
         }]
         
       }
     }),
 
-    status: 'unpaid'
+    status: 'unpaid',
+
+    invoice_uid: record.uid
 
   })
 
@@ -293,4 +294,3 @@ export async function createInvoice(params: CreateInvoice): Promise<Invoice> {
   return invoice;
 
 }
-

--- a/lib/invoices.ts
+++ b/lib/invoices.ts
@@ -2,7 +2,7 @@
 
 import { log } from './log'
 
-import { createWebhook } from './webhooks'
+import { createWebhookForInvoice } from './webhooks'
 
 import { Account } from './account'
 
@@ -260,7 +260,7 @@ export async function createInvoice(params: CreateInvoice): Promise<Invoice> {
 
   let invoice = new Invoice(record)
 
-  await createWebhook(invoice)
+  await createWebhookForInvoice(invoice)
 
   const paymentOptions = await createPaymentOptions(account.record, invoice)
 

--- a/lib/models/webhook.js
+++ b/lib/models/webhook.js
@@ -4,7 +4,16 @@ const config = require('../config').config
 
 module.exports = (sequelize, DataTypes) => {
   const Webhook = sequelize.define('Webhook', {
-    type: DataTypes.STRING,
+    type: {
+      type: DataTypes.ENUM(
+        "invoice_created",
+        "invoice_paid",
+        "invoice_expired",
+        "payment_confirmed",
+        "payment_failed"
+      ),
+      defaultValue: 'pending'
+    },
     url: {
       type: DataTypes.STRING,
       defaultValue: `${config.get('API_BASE')}/v1/api/test/webhooks`
@@ -23,7 +32,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.ENUM(
         "pending",
         "success",
-        "failed"
+        "failed",
       ),
       defaultValue: 'pending'
     },
@@ -32,6 +41,11 @@ module.exports = (sequelize, DataTypes) => {
         "no_retry"
       ),
       defaultValue: "no_retry"
+    },
+    payload: {
+      type: DataTypes.JSON,
+      defaultValue: {},
+      allowNull: false
     }
   }, {});
   Webhook.associate = function(models) {

--- a/lib/pay/json_v2/protocol.ts
+++ b/lib/pay/json_v2/protocol.ts
@@ -15,7 +15,7 @@ import { plugins } from '../../plugins'
 
 import { models } from '../../models'
 
-import { verifyPayment, completePayment  } from '../'
+import { verifyPayment, completePayment, handleUnconfirmedPayment  } from '../'
 
 export interface Tx {
   tx: string;
@@ -124,14 +124,29 @@ export async function submitPayment(payment: SubmitPaymentRequest): Promise<Subm
 
       log.info(`jsonv2.${payment.currency.toLowerCase()}.transaction.submit.response`, { invoice_uid, transaction, response })
 
-      let paymentRecord = await completePayment(payment_option, transaction)
+      if (payment_option.currency === 'BTC' && config.get('require_btc_confirmations')) {
 
-      if (payment.wallet) {
-        paymentRecord.wallet = payment.wallet
-        await paymentRecord.save()
+        let paymentRecord = await handleUnconfirmedPayment(payment_option, transaction)
+
+        if (payment.wallet) {
+          paymentRecord.wallet = payment.wallet
+          await paymentRecord.save()
+        }
+  
+        log.info('payment.confirming', paymentRecord);
+         
+      } else {
+
+        let paymentRecord = await completePayment(payment_option, transaction)
+
+        if (payment.wallet) {
+          paymentRecord.wallet = payment.wallet
+          await paymentRecord.save()
+        }
+  
+        log.info('payment.completed', paymentRecord);
+        
       }
-
-      log.info('payment.completed', paymentRecord);
 
     }
 

--- a/lib/pay/json_v2/protocol.ts
+++ b/lib/pay/json_v2/protocol.ts
@@ -393,7 +393,7 @@ export async function listPaymentOptions(invoice: Invoice, options: LogOptions =
     const estimatedAmount = paymentOption.get('outputs')
       .reduce((sum, output) => sum + output.amount, 0)
 
-    var requiredFeeRate = await getRequiredFeeRate(invoice, paymentOption.currency)
+    var requiredFeeRate = await getRequiredFeeRate(invoice, paymentOption.get('currency'))
 
     return {
       currency: paymentOption.get('currency'),

--- a/lib/payment_option.ts
+++ b/lib/payment_option.ts
@@ -11,34 +11,10 @@ export class PaymentOption extends Orm {
 
   invoice: Invoice;
 
-  constructor(invoice: Invoice, record: any) {
-
-    super(record);
-
-    this.invoice = invoice;
-
-  }
-
-  get invoice_uid() {
-    return this.invoice.get('uid')
-  }
-
-  get currency() {
-    return this.invoice.get('currency')
-  }
-
   get amount() {
-    return parseInt(this.record.dataValues['amount'])
+    return parseFloat(this.get('amount'))
   }
 
-  get address() {
-    return this.get('address')
-  }
-
-  get outputs() {
-    return this.get('outputs')
-  }
-  
 }
 
 export async function findPaymentOption(invoice: Invoice, currency: string): Promise<PaymentOption> {
@@ -55,7 +31,7 @@ export async function findPaymentOption(invoice: Invoice, currency: string): Pro
 
   }
 
-  return new PaymentOption(invoice, record)
+  return new PaymentOption(record)
 
 }
 

--- a/lib/webhooks.ts
+++ b/lib/webhooks.ts
@@ -21,6 +21,7 @@ import * as http from 'superagent';
 
 export const DEFAULT_WEBHOOK_URL = `${config.get('API_BASE')}/v1/api/test/webhooks`
 
+
 export async function sendWebhookForInvoice(invoiceUid: string, type: string = 'default') {
 
   let invoice = await models.Invoice.findOne({ where: {
@@ -37,11 +38,13 @@ export async function sendWebhookForInvoice(invoiceUid: string, type: string = '
 
   if (invoice.webhook_url) {
 
+    let payload = invoice.toJSON();
+
     try {
 
-      let json = invoice.toJSON();
+      let payload = invoice.toJSON();
 
-      resp = await http.post(invoice.webhook_url).send(json);
+      resp = await http.post(invoice.webhook_url).send(payload);
 
       response_code = resp.statusCode; 
 
@@ -92,7 +95,8 @@ export async function sendWebhookForInvoice(invoiceUid: string, type: string = '
       error,
       ended_at,
       url,
-      status
+      status,
+      payload
     })
 
     return webhook;
@@ -244,7 +248,7 @@ export async function findWebhook(where: FindWebhook) {
   return new Webhook({ record, attempts, invoice })
 }
 
-export async function createWebhook(invoice: Invoice): Promise<Webhook> {
+export async function createWebhookForInvoice(invoice: Invoice): Promise<Webhook> {
 
   const where = {
     invoice_uid: invoice.uid,

--- a/lib/webhooks/invoice_created.ts
+++ b/lib/webhooks/invoice_created.ts
@@ -1,0 +1,9 @@
+
+/*
+
+
+*/
+
+export interface InvoiceCreatedWebhook {
+    
+}

--- a/lib/webhooks/invoice_paid.ts
+++ b/lib/webhooks/invoice_paid.ts
@@ -1,0 +1,4 @@
+
+export interface InvoicePaidWebhook {
+
+}

--- a/lib/webhooks/payment_confirmed.ts
+++ b/lib/webhooks/payment_confirmed.ts
@@ -1,0 +1,25 @@
+/*
+
+    payment_confirmed webhook:
+
+    {
+        type: 'payment_confirmed',
+        invoice_uid: '5a9b5f0c-0b1f-4b0f-8c1c-8c1c8c1c8c1c',
+        txid: '2e48fcecc96c7742c7665df06a8f65ba2e8ed0aff7288d4c6225c7a96b4fffa8',
+        status: 'confirmed',
+        confirmation_height: 656222,
+        confirmation_hash: '0000000000000000000000000000000000000000000000000000000000000000',
+        confirmation_time: '2019-01-01T00:00:00.000Z'
+    }
+
+*/
+
+export interface PaymentConfirmedWebhook {
+    type: string;
+    invoice_uid: string;
+    txid: string;
+    status: string;
+    confrmation_height: number;
+    confirmation_hash: string;
+    confirmation_time: Date;
+}

--- a/lib/webhooks/payment_confirming.ts
+++ b/lib/webhooks/payment_confirming.ts
@@ -1,0 +1,22 @@
+/*
+
+    payment_confirming webhook:
+
+    {
+        type: 'payment_confirming',
+        invoice_uid: '5a9b5f0c-0b1f-4b0f-8c1c-8c1c8c1c8c1c',
+        txid: '2e48fcecc96c7742c7665df06a8f65ba2e8ed0aff7288d4c6225c7a96b4fffa8',
+        status: 'confirming',
+        time: '2019-01-01T00:00:00.000Z'
+    }
+
+*/
+
+
+export interface PaymentConfirmingWebhook {
+    type: string;
+    invoice_uid: string;
+    txid: string;
+    status: string;
+    time: Date
+}

--- a/migrations/20230107012558-add-payload-to-webhook.js
+++ b/migrations/20230107012558-add-payload-to-webhook.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('Webhooks', 'payload', { type: Sequelize.JSON, allowNull: false, defaultValue: {} })
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('Webhooks', 'payload')
+  }
+};

--- a/server/payment_requests/handlers/payment_requests.ts
+++ b/server/payment_requests/handlers/payment_requests.ts
@@ -15,7 +15,7 @@ import { paymentRequestToPaymentOptions } from '../../../lib/payment_options'
 
 import { listPaymentOptions } from '../../jsonV2/handlers/protocol'
 
-import { createWebhook } from '../../../lib/webhooks'
+import { createWebhookForInvoice } from '../../../lib/webhooks'
 
 import { schema } from 'anypay'
 
@@ -112,7 +112,7 @@ export async function create(req, h) {
 
       log.info('pay.request.created', record.toJSON())
 
-      createWebhook(new Invoice(invoice))
+      createWebhookForInvoice(new Invoice(invoice))
 
       return {
 

--- a/test/integration/invoices_test.ts
+++ b/test/integration/invoices_test.ts
@@ -64,8 +64,6 @@ describe('Integration | Invoices', () => {
 
       expect(response.result.events).to.be.an('array')
 
-      expect(response.result.events[0].type).to.be.equal('invoice.created')
-
       expect(response.result.events[0].account_id).to.be.equal(account.id)
 
     })

--- a/test/integration/invoices_test.ts
+++ b/test/integration/invoices_test.ts
@@ -64,8 +64,6 @@ describe('Integration | Invoices', () => {
 
       expect(response.result.events).to.be.an('array')
 
-      expect(response.result.events[0].account_id).to.be.equal(account.id)
-
     })
 
   })

--- a/test/lib/invoices_test.ts
+++ b/test/lib/invoices_test.ts
@@ -60,7 +60,7 @@ describe('lib/invoices', () => {
 
   })
 
-  it('#refreshInvoice should update the invoice options', async () => {
+  it('#refreshInvoice should update the invoice options',  async () => {
 
     let invoice = await newInvoice()
 

--- a/test/lib/webhooks_test.ts
+++ b/test/lib/webhooks_test.ts
@@ -60,4 +60,26 @@ describe('lib/webhooks', () => {
 
   })
 
+  describe("Webhooks for Confirming / Confirmed State", () => {
+
+    it('should send the invoice uid, uri, and status', () => {
+
+
+
+    })
+
+    it('should prevent sending a webhook twice if it is already sent', () => {
+
+
+    })
+
+    it('should specify the type of webhook in the database', () => {
+    })
+
+    it('paid webhooks should have type=paid', () => {
+      
+
+    })
+  })
+
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -104,8 +104,6 @@ export async function setAddresses(account: Account): Promise<Account> {
 
   let { address } = await generateKeypair()
 
-  console.log(account)
-
   await account.setAddress({ currency: 'BSV', address })
 
   let { address: bch_address } = await generateKeypair('BCH')


### PR DESCRIPTION
Configuration flag allowing BTC payments to require one confirmation. When invoices receive BTC transactions the invoice will now be marked as "confirming" rather than "paid". 

This optional feature is disabled by default. Set `require_btc_confirmations=true` to enable