### PR TITLE
Accept Txid For EVM Payments For Manual Testing

### DIFF
--- a/lib/pay/index.ts
+++ b/lib/pay/index.ts
@@ -384,7 +384,15 @@ export async function completePayment(paymentOption, transaction: Transaction, c
 
   if (!txid) {
 
-    txid = (await parsePayments({ chain, currency, transaction }))[0].txid
+    if (txhex.length == 66) {
+
+      txid = txhex
+
+    } else {
+
+      txid = (await parsePayments({ chain, currency, transaction }))[0].txid
+
+    }
 
   }
 

--- a/wallet/bin/submit_payment.ts
+++ b/wallet/bin/submit_payment.ts
@@ -1,0 +1,59 @@
+
+
+require('dotenv').config()
+
+import { Cards, PaymentOption } from '../src'
+
+import axios from 'axios'
+
+async function main() {
+
+  const chain = process.argv[2]
+
+  const currency = process.argv[3]
+
+  const uid = process.argv[4]
+
+  const txid = process.argv[5]
+
+  const Card = Cards.getCard({ chain, currency })
+
+  const card = new Card({
+    phrase: process.env.anypay_wallet_phrase
+  })
+
+  //const base = 'https://develop.anypayx.com'
+  const base = 'http://localhost:5211'
+
+  const url = `${base}/r/${uid}`
+
+  try {
+
+    const { data: paymentResult } = await axios.post(url, {
+      chain,
+      currency,
+      transactions: [{ tx: txid }]
+    }, {
+      headers: {
+        'content-type': 'application/payment'
+      }
+    })
+
+    console.log({ paymentResult })
+
+    process.exit()
+
+  } catch(error) {
+
+    console.log(error)
+
+    console.error(error.response.data)
+
+    process.exit(1)
+
+  }
+
+}
+
+main()
+


### PR DESCRIPTION
This update is required for accepting transactions via web3-checkout (metamask & brave wallet, etc).

It also includes a command line tool for manually submitting a transaction by txid.